### PR TITLE
fix: page reload issue on starting characters inputs

### DIFF
--- a/apps/snow-leopard/app/documents/page.tsx
+++ b/apps/snow-leopard/app/documents/page.tsx
@@ -1,25 +1,5 @@
-import { redirect } from 'next/navigation';
-import { getSession, getUser } from '@/app/(auth)/auth';
-import { AlwaysVisibleArtifact } from '@/components/document/document-workspace';
+import { createNewDocument } from './actions';
 
 export default async function Page() {
-  const session = await getSession();
-
-  if (!session?.user?.id) { 
-    redirect('/'); 
-  }
-
-  const user = await getUser();
-  if (!user) {
-    redirect('/');
-  }
-
-  return (
-    <AlwaysVisibleArtifact 
-      chatId="new-chat"
-      initialDocumentId="init"
-      initialDocuments={[]} 
-      user={user}
-    />
-  );
-} 
+  await createNewDocument()
+}

--- a/apps/snow-leopard/lib/db/queries.ts
+++ b/apps/snow-leopard/lib/db/queries.ts
@@ -806,6 +806,32 @@ export async function getLatestDocumentById({ id }: { id: string }): Promise<(ty
   }
 }
 
+export async function getLatestDocumentByUserId({ userId }: { userId: string }): Promise<(typeof schema.Document.$inferSelect) | null> {
+  try {
+    if (!userId) {
+      console.warn(`[DB Query - getLatestDocumentByUserId] Invalid user ID provided: ${userId}`);
+      return null;
+    }
+
+    const data = await db
+      .select()
+      .from(schema.Document)
+      .where(eq(schema.Document.userId, userId))
+      .orderBy(desc(schema.Document.createdAt))
+      .limit(1);
+
+    if (!data || data.length === 0) {
+      console.log(`[DB Query - getLatestDocumentByUserId] No documents ${data} found for user: ${userId}`);
+      return null
+    }
+
+    return data[0]; // Return the latest document found
+  } catch (error) {
+    console.error(`[DB Query - getLatestDocumentByUserId] Error fetching latest document for user ${userId}:`, error);
+    return null;
+  }
+}
+
 // --- Subscription Queries --- //
 
 // Define the type for the subscription based on your schema


### PR DESCRIPTION
Hi, I have noticed that whenever the user signin and started to write something, the /documents page reloads or refresh because it is redirected to documents/new-id-bla bla.

This leaves a bad impression on a new user and he get a false likelihood that the product has bugs

I have solved this issue but directly landing the user to documents/new-id-bla-bla, so that the page should not render or refresh. I have also handled the case that if the previous page which the user leaves has not contained anything and its title is still "Untitle Document", then that page should reopen instead of creating new ones.

I am also attaching a video that explains it

If something is unclear, please comment on it, i will try to reply. I request you to provide any feedback or merge my code.

Thanks

Before

https://github.com/user-attachments/assets/084783f8-537d-4d00-ab61-128b4f360fcf

After


https://github.com/user-attachments/assets/45f78943-65cf-4d67-8fc9-c3f2b87ef0b4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic creation of a new “Untitled Document” on visit; if an empty one already exists, you’ll be redirected to it.
  - Seamless redirect to the editor after starting a document.

- Bug Fixes
  - Improved error handling when updating a document that no longer exists, preventing silent failures and surfacing errors.

- Refactor
  - Streamlined the Documents page to immediately handle document creation/redirect for a faster, smoother start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->