### PR TITLE
Replace decommissioned Llama 4 Maverick with GPT OSS 120B as default

### DIFF
--- a/apps/saru/lib/ai/models.ts
+++ b/apps/saru/lib/ai/models.ts
@@ -10,16 +10,17 @@ interface ChatModel {
 export const chatModels: Array<ChatModel> = [
   {
     id: 'chat-model-small',
-    name: 'Llama 4',
-    description: 'Small and fast model',
+    name: 'GPT OSS 120B',
+    description: 'Recommended default model',
   },
   {
     id: 'chat-model-large',
     name: 'Kimi K2',
-    description: 'Large and powerful model',  },
+    description: 'Large and powerful model',
+  },
   {
     id: 'chat-model-reasoning',
-    name: 'GPT OSS',
+    name: 'GPT OSS 120B (Reasoning)',
     description: 'Advanced reasoning model',
   },
 ];

--- a/apps/saru/lib/ai/providers.ts
+++ b/apps/saru/lib/ai/providers.ts
@@ -7,12 +7,12 @@ import { groq } from '@ai-sdk/groq';
 
 export const myProvider = customProvider({
   languageModels: {
-        'chat-model-small': groq('meta-llama/llama-4-maverick-17b-128e-instruct'),
-        'chat-model-large': groq('moonshotai/kimi-k2-instruct-0905'),
-        'chat-model-reasoning': wrapLanguageModel({
-          model: groq('openai/gpt-oss-120b'),
-          middleware: extractReasoningMiddleware({ tagName: 'think' }),
-        }),
+    'chat-model-small': groq('openai/gpt-oss-120b'),
+    'chat-model-large': groq('moonshotai/kimi-k2-instruct-0905'),
+    'chat-model-reasoning': wrapLanguageModel({
+      model: groq('openai/gpt-oss-120b'),
+      middleware: extractReasoningMiddleware({ tagName: 'think' }),
+    }),
     'title-model': groq('llama-3.1-8b-instant'),
     'artifact-model': groq('meta-llama/llama-4-scout-17b-16e-instruct'),
   },


### PR DESCRIPTION
### Motivation
- The Groq-hosted `meta-llama/llama-4-maverick-17b-128e-instruct` model was decommissioned and default requests started failing, so the default must be changed to a supported model.
- Use `gpt-oss-120b` as the recommended replacement to restore default chat functionality and align reasoning and default paths.

### Description
- Updated the provider mapping in `apps/saru/lib/ai/providers.ts` to set `'chat-model-small'` to `groq('openai/gpt-oss-120b')` instead of the decommissioned Groq Llama entry.
- Left the reasoning model as `openai/gpt-oss-120b` with `extractReasoningMiddleware`, keeping reasoning behavior unchanged.
- Updated user-facing labels in `apps/saru/lib/ai/models.ts` to show `GPT OSS 120B` for the default and `GPT OSS 120B (Reasoning)` for the reasoning option.
- Ran automatic formatting on the modified files.

### Testing
- Ran formatting with `pnpm -s format` on the modified files, which succeeded.
- Ran the app linter via `pnpm -s lint:app`, which completed successfully with existing warnings only.
- Started the dev server (`pnpm dev`) and verified the app booted and served pages, noting external network warnings for Google Fonts and GitHub API but the server ran.
- Captured a Playwright screenshot of the running site, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af2b0b3e1c8325a7d3f356882c5284)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Default chat model changed to GPT OSS 120B with clarified description as "Recommended default model"
  * Reasoning model renamed to GPT OSS 120B (Reasoning) for consistency
  * Improved model naming and descriptions for better user guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->