### PR TITLE
Update Groq models: replace deprecated Kimi K2

### DIFF
--- a/apps/saru/lib/ai/models.ts
+++ b/apps/saru/lib/ai/models.ts
@@ -10,17 +10,17 @@ interface ChatModel {
 export const chatModels: Array<ChatModel> = [
   {
     id: 'chat-model-small',
-    name: 'GPT OSS 120B',
-    description: 'Recommended default model',
+    name: 'Small Model',
+    description: 'Fast and efficient for everyday tasks',
   },
   {
     id: 'chat-model-large',
-    name: 'Kimi K2',
-    description: 'Large and powerful model',
+    name: 'Large Model',
+    description: 'Powerful model for complex tasks',
   },
   {
     id: 'chat-model-reasoning',
-    name: 'GPT OSS 120B (Reasoning)',
-    description: 'Advanced reasoning model',
+    name: 'Reasoning Model',
+    description: 'Advanced step-by-step reasoning',
   },
 ];

--- a/apps/saru/lib/ai/providers.ts
+++ b/apps/saru/lib/ai/providers.ts
@@ -7,13 +7,13 @@ import { groq } from '@ai-sdk/groq';
 
 export const myProvider = customProvider({
   languageModels: {
-    'chat-model-small': groq('openai/gpt-oss-120b'),
-    'chat-model-large': groq('moonshotai/kimi-k2-instruct-0905'),
+    'chat-model-small': groq('openai/gpt-oss-20b'),
+    'chat-model-large': groq('openai/gpt-oss-120b'),
     'chat-model-reasoning': wrapLanguageModel({
-      model: groq('openai/gpt-oss-120b'),
+      model: groq('deepseek-r1-distill-qwen-32b'),
       middleware: extractReasoningMiddleware({ tagName: 'think' }),
     }),
-    'title-model': groq('llama-3.1-8b-instant'),
+    'title-model': groq('openai/gpt-oss-20b'),
     'artifact-model': groq('meta-llama/llama-4-scout-17b-16e-instruct'),
   },
 });


### PR DESCRIPTION
## Summary
- **Small Model**: `openai/gpt-oss-20b` — fast, cost-efficient for everyday tasks
- **Large Model**: `openai/gpt-oss-120b` — powerful, no reasoning brackets
- **Reasoning Model**: `deepseek-r1-distill-qwen-32b` — chain-of-thought with `<think>` tags
- Title model upgraded from `llama-3.1-8b-instant` to `openai/gpt-oss-20b`
- Consumer-friendly display names: Small Model / Large Model / Reasoning Model

Replaces the deprecated `moonshotai/kimi-k2-instruct-0905` (deprecation effective April 15, 2026).

## Test plan
- [ ] Verify chat works with Small Model (default)
- [ ] Verify chat works with Large Model
- [ ] Verify Reasoning Model outputs chain-of-thought correctly
- [ ] Verify title generation still works with new gpt-oss-20b
- [ ] Verify artifact generation unchanged with Llama 4 Scout

https://claude.ai/code/session_01GfZE1qvKC8jKqWfZRrFRRC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Improved chat model display information with updated names and descriptions for better user guidance.
  * Refreshed underlying AI provider configurations to enhance performance and optimize capabilities across small, large, and reasoning model categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->