### PR TITLE
Update Groq models: non-reasoning small/large, GPT-OSS reasoning

### DIFF
--- a/apps/saru/lib/ai/providers.ts
+++ b/apps/saru/lib/ai/providers.ts
@@ -7,8 +7,8 @@ import { groq } from '@ai-sdk/groq';
 
 export const myProvider = customProvider({
   languageModels: {
-    'chat-model-small': groq('openai/gpt-oss-120b'),
-    'chat-model-large': groq('deepseek-r1-distill-qwen-32b'),
+    'chat-model-small': groq('openai/gpt-oss-20b'),
+    'chat-model-large': groq('llama-3.3-70b-versatile'),
     'chat-model-reasoning': wrapLanguageModel({
       model: groq('openai/gpt-oss-120b'),
       middleware: extractReasoningMiddleware({ tagName: 'think' }),

--- a/apps/saru/lib/ai/providers.ts
+++ b/apps/saru/lib/ai/providers.ts
@@ -7,7 +7,7 @@ import { groq } from '@ai-sdk/groq';
 
 export const myProvider = customProvider({
   languageModels: {
-    'chat-model-small': groq('openai/gpt-oss-20b'),
+    'chat-model-small': groq('llama-3.1-8b-instant'),
     'chat-model-large': groq('llama-3.3-70b-versatile'),
     'chat-model-reasoning': wrapLanguageModel({
       model: groq('openai/gpt-oss-120b'),

--- a/apps/saru/lib/ai/providers.ts
+++ b/apps/saru/lib/ai/providers.ts
@@ -7,10 +7,10 @@ import { groq } from '@ai-sdk/groq';
 
 export const myProvider = customProvider({
   languageModels: {
-    'chat-model-small': groq('openai/gpt-oss-20b'),
-    'chat-model-large': groq('openai/gpt-oss-120b'),
+    'chat-model-small': groq('openai/gpt-oss-120b'),
+    'chat-model-large': groq('deepseek-r1-distill-qwen-32b'),
     'chat-model-reasoning': wrapLanguageModel({
-      model: groq('deepseek-r1-distill-qwen-32b'),
+      model: groq('openai/gpt-oss-120b'),
       middleware: extractReasoningMiddleware({ tagName: 'think' }),
     }),
     'title-model': groq('openai/gpt-oss-20b'),


### PR DESCRIPTION
## Summary
- **Small Model**: `llama-3.1-8b-instant` — non-reasoning, fastest on Groq
- **Large Model**: `llama-3.3-70b-versatile` — non-reasoning, 70B versatile
- **Reasoning Model**: `openai/gpt-oss-120b` — with `<think>` tag middleware
- Title model: `openai/gpt-oss-20b`
- Consumer-friendly display names: Small Model / Large Model / Reasoning Model

Replaces the deprecated `moonshotai/kimi-k2-instruct-0905` (effective April 15, 2026).

## Test plan
- [ ] Verify chat works with Small Model (default)
- [ ] Verify chat works with Large Model
- [ ] Verify Reasoning Model outputs chain-of-thought correctly
- [ ] Verify title generation works with gpt-oss-20b
- [ ] Verify artifact generation unchanged with Llama 4 Scout

https://claude.ai/code/session_01GfZE1qvKC8jKqWfZRrFRRC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI model configurations for enhanced performance across chat and reasoning features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->