### PR TITLE
Fix auth redirect loop, session expiry, double-click navigation, and …

### DIFF
--- a/apps/saru/app/(auth)/login/page.tsx
+++ b/apps/saru/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 import { authClient } from '@/lib/auth-client';
 import { toast } from '@/components/toast';
@@ -14,6 +14,11 @@ const githubEnabled = process.env.NEXT_PUBLIC_GITHUB_ENABLED === 'true';
 
 export default function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const rawRedirect = searchParams.get('redirect') ?? '';
+  const redirectTo = rawRedirect.startsWith('/') && !rawRedirect.startsWith('//')
+    ? rawRedirect
+    : '/documents';
   const [isEmailLoading, setIsEmailLoading] = useState(false);
   const [isSocialLoading, setIsSocialLoading] = useState<string | null>(null);
   const [isSuccessful, setIsSuccessful] = useState(false);
@@ -27,7 +32,7 @@ export default function LoginPage() {
     await authClient.signIn.email({
       email: currentEmail,
       password,
-      callbackURL: "/documents"
+      callbackURL: redirectTo,
     }, {
       onRequest: () => {
         setIsEmailLoading(true);
@@ -58,8 +63,8 @@ export default function LoginPage() {
   const handleSocialLogin = async (provider: 'google' | 'github') => {
     await authClient.signIn.social({
       provider,
-      callbackURL: "/documents",
-      errorCallbackURL: "/login?error=social_signin_failed",
+      callbackURL: redirectTo,
+      errorCallbackURL: `/login?redirect=${encodeURIComponent(redirectTo)}&error=social_signin_failed`,
     }, {
       onRequest: () => {
         setIsSocialLoading(provider);
@@ -110,7 +115,7 @@ export default function LoginPage() {
         <p className="text-center text-sm text-gray-600 dark:text-zinc-400">
           {"Don't have an account? "}
           <Link
-            href="/register"
+            href={redirectTo !== '/documents' ? `/register?redirect=${encodeURIComponent(redirectTo)}` : '/register'}
             className="font-semibold text-gray-800 hover:underline dark:text-zinc-200"
           >
             Sign up

--- a/apps/saru/app/(auth)/register/page.tsx
+++ b/apps/saru/app/(auth)/register/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 import { authClient } from '@/lib/auth-client';
 import { toast } from '@/components/toast';
@@ -14,6 +14,11 @@ const emailVerificationEnabled = process.env.NEXT_PUBLIC_EMAIL_VERIFY_ENABLED ==
 
 export default function RegisterPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const rawRedirect = searchParams.get('redirect') ?? '';
+  const redirectTo = rawRedirect.startsWith('/') && !rawRedirect.startsWith('//')
+    ? rawRedirect
+    : '/documents';
   const [isEmailLoading, setIsEmailLoading] = useState(false);
   const [isSocialLoading, setIsSocialLoading] = useState<string | null>(null);
   const [isSuccessful, setIsSuccessful] = useState(false);
@@ -50,7 +55,7 @@ export default function RegisterPage() {
             type: 'success',
             description: 'Account created! Redirecting...'
           });
-          router.push('/documents'); 
+          router.push(redirectTo);
         }
       },
       onError: (ctx) => {
@@ -68,8 +73,8 @@ export default function RegisterPage() {
   const handleSocialLogin = async (provider: 'google' | 'github') => {
     await authClient.signIn.social({
       provider,
-      callbackURL: "/documents", 
-      errorCallbackURL: "/register?error=social_signin_failed",
+      callbackURL: redirectTo,
+      errorCallbackURL: `/register?redirect=${encodeURIComponent(redirectTo)}&error=social_signin_failed`,
     }, {
       onRequest: () => {
         setIsSocialLoading(provider);

--- a/apps/saru/app/page.tsx
+++ b/apps/saru/app/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { Crimson_Text } from "next/font/google";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
 import { Button } from "@/components/ui/button";
@@ -20,6 +20,7 @@ const crimson = Crimson_Text({
 
 export default function Home() {
   const router = useRouter();
+  const [isPending, startTransition] = useTransition();
 
   const { data: session } = authClient.useSession();
   const hasSession = !!session?.user;
@@ -39,11 +40,14 @@ export default function Home() {
   }, []);
 
   const handleBeginClick = () => {
-    if (hasSession) {
-      router.push("/documents");
-    } else {
-      router.push("/login?redirect=/documents");
-    }
+    if (isPending) return;
+    startTransition(() => {
+      if (hasSession) {
+        router.push("/documents");
+      } else {
+        router.push("/login?redirect=/documents");
+      }
+    });
   };
 
   const modelNames = ["Llama", "Kimi", "Deepseek", "Claude"] as const;
@@ -56,6 +60,7 @@ export default function Home() {
         hasSession={hasSession}
         animatedStarCount={animatedStarCount}
         onBeginClick={handleBeginClick}
+        isNavigating={isPending}
       />
 
       {/* Hero Section */}
@@ -115,6 +120,7 @@ export default function Home() {
               size="sm"
               className="rounded-full"
               onClick={handleBeginClick}
+              disabled={isPending}
             >
               {hasSession ? "Open" : "Begin"}{" "}
               <span className="inline-block ml-2 text-xs transition-transform group-hover:translate-x-0.5">
@@ -265,6 +271,7 @@ export default function Home() {
               size="lg"
               className="rounded-full px-8 py-3"
               onClick={handleBeginClick}
+              disabled={isPending}
             >
               {hasSession ? "Open Saru" : "Get Started"}
             </Button>

--- a/apps/saru/components/landing/header.tsx
+++ b/apps/saru/components/landing/header.tsx
@@ -9,9 +9,10 @@ interface HeaderProps {
   hasSession: boolean;
   animatedStarCount: number;
   onBeginClick: () => void;
+  isNavigating?: boolean;
 }
 
-export function Header({ hasSession, animatedStarCount, onBeginClick }: HeaderProps) {
+export function Header({ hasSession, animatedStarCount, onBeginClick, isNavigating }: HeaderProps) {
   return (
     <header className="absolute top-0 w-full z-10 py-4">
       <div className="container mx-auto flex justify-between items-center px-6 md:px-8 lg:px-12">
@@ -58,6 +59,7 @@ export function Header({ hasSession, animatedStarCount, onBeginClick }: HeaderPr
             size="sm"
             className="rounded-full group flex items-center h-8"
             onClick={onBeginClick}
+            disabled={isNavigating}
           >
             {hasSession ? "Open" : "Begin"}
             <span className="inline-block ml-2 text-xs transition-transform group-hover:translate-x-0.5">

--- a/apps/saru/lib/auth.ts
+++ b/apps/saru/lib/auth.ts
@@ -120,9 +120,14 @@ if (githubEnabled) {
 }
 
 export const auth = betterAuth({
-  database: drizzleAdapter(db, { 
+  database: drizzleAdapter(db, {
     provider: 'pg',
   }),
+
+  session: {
+    expiresIn: 60 * 60 * 24 * 30,
+    updateAge: 60 * 60 * 24,
+  },
 
   socialProviders,
 

--- a/apps/saru/providers/posthog-provider.tsx
+++ b/apps/saru/providers/posthog-provider.tsx
@@ -19,8 +19,30 @@ if (posthogEnabled && typeof window !== 'undefined' && posthogKey && posthogHost
 }
 
 export function CSPostHogProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    if (!posthogEnabled) return;
+
+    const handleError = (event: ErrorEvent) => {
+      posthog.captureException(event.error ?? new Error(event.message));
+    };
+
+    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+      const err = event.reason instanceof Error
+        ? event.reason
+        : new Error(String(event.reason));
+      posthog.captureException(err);
+    };
+
+    window.addEventListener('error', handleError);
+    window.addEventListener('unhandledrejection', handleUnhandledRejection);
+
+    return () => {
+      window.removeEventListener('error', handleError);
+      window.removeEventListener('unhandledrejection', handleUnhandledRejection);
+    };
+  }, []);
+
   if (!posthogEnabled || !posthogKey || !posthogHost) {
-    console.warn('PostHog not enabled or configured. Skipping initialization.');
     return <>{children}</>;
   }
 


### PR DESCRIPTION
…error tracking

- login/register: read ?redirect param and use as callbackURL (was hardcoded to /documents); validates it's a relative path to prevent open redirect
- login: forward redirect param through Sign up link and OAuth error callback URLs
- auth: set session.expiresIn (30d) + updateAge (1d) for rolling refresh, stopping mid-session logouts for engaged users
- homepage: wrap router.push in useTransition; all three CTA buttons disabled while pending to prevent duplicate navigation on rapid clicks
- posthog: wire window.error + unhandledrejection to posthog.captureException so JS exceptions actually appear in PostHog