### PR TITLE
Update AI model providers to use Groq-hosted models

### DIFF
--- a/apps/saru/lib/ai/providers.ts
+++ b/apps/saru/lib/ai/providers.ts
@@ -7,13 +7,13 @@ import { groq } from '@ai-sdk/groq';
 
 export const myProvider = customProvider({
   languageModels: {
-    'chat-model-small': groq('meta-llama/llama-4-scout-17b-16e-instruct'),
-    'chat-model-large': groq('openai/gpt-oss-120b'),
+    'chat-model-small': groq('llama-3.1-8b-instant'),
+    'chat-model-large': groq('moonshotai/kimi-k2-instruct-0905'),
     'chat-model-reasoning': wrapLanguageModel({
       model: groq('openai/gpt-oss-120b'),
       middleware: extractReasoningMiddleware({ tagName: 'think' }),
     }),
-    'title-model': groq('openai/gpt-oss-20b'),
-    'artifact-model': groq('meta-llama/llama-4-scout-17b-16e-instruct'),
+    'title-model': groq('llama-3.1-8b-instant'),
+    'artifact-model': groq('moonshotai/kimi-k2-instruct-0905'),
   },
 });


### PR DESCRIPTION
## Summary
Updated the AI provider configuration to use different Groq-hosted language models across various use cases.

## Key Changes
- **Small chat model**: Changed from `meta-llama/llama-4-scout-17b-16e-instruct` to `llama-3.1-8b-instant`
- **Large chat model**: Changed from `openai/gpt-oss-120b` to `moonshotai/kimi-k2-instruct-0905`
- **Title generation model**: Changed from `openai/gpt-oss-20b` to `llama-3.1-8b-instant`
- **Artifact generation model**: Changed from `meta-llama/llama-4-scout-17b-16e-instruct` to `moonshotai/kimi-k2-instruct-0905`

Note: The reasoning model continues to use `openai/gpt-oss-120b` with the existing reasoning middleware.

## Implementation Details
All model updates are made through the Groq provider (`groq()` function), maintaining consistency with the existing provider architecture. The changes optimize model selection for different tasks while keeping the same provider infrastructure.

https://claude.ai/code/session_015vVRbEdz7qnev3dRkC3WXD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the AI models used for chat responses, title generation, and artifact creation.
  * Reasoning chat behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->