### PR TITLE
Use llama-3.3-70b-versatile for large/artifact tiers

### DIFF
--- a/apps/saru/lib/ai/providers.ts
+++ b/apps/saru/lib/ai/providers.ts
@@ -8,12 +8,12 @@ import { groq } from '@ai-sdk/groq';
 export const myProvider = customProvider({
   languageModels: {
     'chat-model-small': groq('llama-3.1-8b-instant'),
-    'chat-model-large': groq('moonshotai/kimi-k2-instruct-0905'),
+    'chat-model-large': groq('llama-3.3-70b-versatile'),
     'chat-model-reasoning': wrapLanguageModel({
       model: groq('openai/gpt-oss-120b'),
       middleware: extractReasoningMiddleware({ tagName: 'think' }),
     }),
     'title-model': groq('llama-3.1-8b-instant'),
-    'artifact-model': groq('moonshotai/kimi-k2-instruct-0905'),
+    'artifact-model': groq('llama-3.3-70b-versatile'),
   },
 });


### PR DESCRIPTION
Kimi K2 wasn't serving on the target Groq tier. Switch the large and artifact tiers to llama-3.3-70b-versatile, Groq's canonical non-reasoning large model with full tool-calling support and the same family as the small tier.


Claude-Session: https://claude.ai/code/session_015vVRbEdz7qnev3dRkC3WXD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the AI model powering large chat responses and artifact generation for improved capabilities and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->